### PR TITLE
Fix broken --regression flag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def pytest_generate_tests(metafunc):
         cmr_dirpath = pathlib.Path('cmr')
 
         association_dir = 'uat' if metafunc.config.option.env == 'uat' else 'ops'
-        associations = [os.listdir(cmr_dirpath.joinpath(association_dir))]
+        associations = os.listdir(cmr_dirpath.joinpath(association_dir))
 
         if 'collection_concept_id' in metafunc.fixturenames and associations is not None:
             metafunc.parametrize("collection_concept_id", associations)


### PR DESCRIPTION
The command `poetry run pytest tests/verify_collection.py --regression --env uat`

Was collecting only a single item for test instead of all collections:
```
collected 1 item                                                                       

tests/verify_collection.py::test_spatial_subset[collection_concept_id0] SKIPPED
```