### PR TITLE
update how ofter our github action runs

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,11 +1,11 @@
-# This workflow scans CMR every 5 minutes to check for new collection associations to the l2ss-py UMM-S record
+# This workflow scans CMR at 1 am pst each 3 days to check for new collection associations to the l2ss-py UMM-S record
 #  in UAT and OPS. If a new association is found, a PR is opened to add the new collection concept id to the
 #  cmr/*_associations.txt file.
 name: Scan For New Associations
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 1 */3 * *'
 
 jobs:
   find_new:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,8 +1,8 @@
 name: Re-Run Unverified PRs
 on:
     workflow_dispatch:
-    schedule: 
-      - cron:  '00 5 * * *'
+#    schedule: 
+#      - cron:  '00 5 * * *'
 
 jobs:
   send_pull_requests:


### PR DESCRIPTION
- remove the github action cron to run open pr
- update diff github action to run at 1 am pst every 3 days
- looks like scan triggers the open pr so we don't need to have github action to run open pr