### PR TITLE
build: implement separation of tasks in Actions diff.yml for improved debugging

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,7 +1,9 @@
-# Run every third day starting from the 2nd of the month 1 am pacific 
-# check for new collection associations to the l2ss-py UMM-S record
-# in UAT and OPS. If a new association is found, a PR is opened to add the new collection concept id to the
-# cmr/l2ss-py/*_associations.txt file.
+# Run every third day starting from the 2n d of the month 1 am pacific
+# check
+for new collection associations to the l2ss - py UMM - S record
+# in UAT and OPS.If a new association is found, a PR is opened to add the new collection concept id to the
+# cmr / l2ss - py
+/*_associations.txt file.
 
 name: Scan For New Associations
 on:
@@ -14,8 +16,8 @@ jobs:
     name: Find new associations
     runs-on: ubuntu-latest
     outputs:
-      new_uat_associations: ${{ steps.diff.outputs.new_uat_associations }}
-      new_ops_associations: ${{ steps.diff.outputs.new_ops_associations }}
+      new_uat_associations: ${{ steps.diff_uat.outputs.new_uat_associations }}
+      new_ops_associations: ${{ steps.diff_ops.outputs.new_ops_associations }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -25,26 +27,28 @@ jobs:
         uses: abatilo/actions-poetry@v3
         with:
           poetry-version: 1.5.1
-      - name: Run diff
-        id: diff
-        env:
-          UAT_TOKEN_TEMP: ${{ secrets.LAUNCHPAD_TOKEN_UAT }}
-          OPS_TOKEN_TEMP: ${{ secrets.LAUNCHPAD_TOKEN_OPS }}
+      -name: Install l2ss-py-autotest
         run: |
           poetry install
-
+      - name: Run diff in UAT
+        id: diff_uat
+        env:
+          UAT_TOKEN_TEMP: ${{ secrets.LAUNCHPAD_TOKEN_UAT }}
+        run: |
           ls $GITHUB_WORKSPACE/tests/cmr/l2ss-py/uat/ > $GITHUB_WORKSPACE/tests/cmr/l2ss-py/uat_associations.txt
-          ls $GITHUB_WORKSPACE/tests/cmr/l2ss-py/ops/ > $GITHUB_WORKSPACE/tests/cmr/l2ss-py/ops_associations.txt
-
           poetry run cmr_association_diff -e uat -t service -p POCLOUD -n 'PODAAC L2 Cloud Subsetter' -a $GITHUB_WORKSPACE/tests/cmr/l2ss-py/uat_associations.txt --token $UAT_TOKEN_TEMP > $GITHUB_WORKSPACE/tests/cmr/l2ss-py/new_uat_associations.txt
-          poetry run cmr_association_diff -e ops -t service -p POCLOUD -n 'PODAAC L2 Cloud Subsetter' -a $GITHUB_WORKSPACE/tests/cmr/l2ss-py/ops_associations.txt --token $OPS_TOKEN_TEMP > $GITHUB_WORKSPACE/tests/cmr/l2ss-py/new_ops_associations.txt
-
           echo "new_uat_associations=$(poetry run python tests/collection_names.py --env uat --token $UAT_TOKEN_TEMP --file $GITHUB_WORKSPACE/tests/cmr/l2ss-py/new_uat_associations.txt)" >> $GITHUB_OUTPUT
-          echo "new_ops_associations=$(poetry run python tests/collection_names.py --env ops --token $OPS_TOKEN_TEMP --file $GITHUB_WORKSPACE/tests/cmr/l2ss-py/new_ops_associations.txt)" >> $GITHUB_OUTPUT
-
           rm $GITHUB_WORKSPACE/tests/cmr/l2ss-py/uat_associations.txt
-          rm $GITHUB_WORKSPACE/tests/cmr/l2ss-py/ops_associations.txt
           rm $GITHUB_WORKSPACE/tests/cmr/l2ss-py/new_uat_associations.txt
+      - name: Run diff in OPS
+        id: diff_ops
+        env:
+          OPS_TOKEN_TEMP: ${{ secrets.LAUNCHPAD_TOKEN_OPS }}
+        run: |
+          ls $GITHUB_WORKSPACE/tests/cmr/l2ss-py/ops/ > $GITHUB_WORKSPACE/tests/cmr/l2ss-py/ops_associations.txt
+          poetry run cmr_association_diff -e ops -t service -p POCLOUD -n 'PODAAC L2 Cloud Subsetter' -a $GITHUB_WORKSPACE/tests/cmr/l2ss-py/ops_associations.txt --token $OPS_TOKEN_TEMP > $GITHUB_WORKSPACE/tests/cmr/l2ss-py/new_ops_associations.txt
+          echo "new_ops_associations=$(poetry run python tests/collection_names.py --env ops --token $OPS_TOKEN_TEMP --file $GITHUB_WORKSPACE/tests/cmr/l2ss-py/new_ops_associations.txt)" >> $GITHUB_OUTPUT
+          rm $GITHUB_WORKSPACE/tests/cmr/l2ss-py/ops_associations.txt
           rm $GITHUB_WORKSPACE/tests/cmr/l2ss-py/new_ops_associations.txt
   open_pr_uat:
     needs: find_new

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,9 +1,7 @@
-# Run every third day starting from the 2n d of the month 1 am pacific
-# check
-for new collection associations to the l2ss - py UMM - S record
-# in UAT and OPS.If a new association is found, a PR is opened to add the new collection concept id to the
-# cmr / l2ss - py
-/*_associations.txt file.
+# Run every third day starting from the 2nd of the month 1 am pacific 
+# check for new collection associations to the l2ss-py UMM-S record
+# in UAT and OPS. If a new association is found, a PR is opened to add the new collection concept id to the
+# cmr/l2ss-py/*_associations.txt file.
 
 name: Scan For New Associations
 on:


### PR DESCRIPTION
This PR is in response to @jamesfwood 's request to investigate https://github.com/podaac/l2ss-py-autotest/actions/runs/11288729065/job/31397095884

I propose to separate the following three concerns into individual tasks

* installing the l2ss-py-autotest library
* running the diff in UAT
* running the diff in OPS

This will improve logging in the GitHub Actions tab and facilitate easier debugging if and when something goes wrong. 