### PR TITLE
update github actions to get launchpad token via lambda

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -23,11 +23,70 @@ jobs:
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: 1.5.1
+
+      - name: Configure AWS credentials for OPS
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CUMULUS_OPS }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CUMULUS_OPS }}
+          aws-region: us-west-2
+
+      - name: Get Lauchpad Token OPS
+        id: launchpad_token_generator_ops
+        run: |
+          OUTPUT_FILE=result.json
+
+          PAYLOAD=$(echo '{"client_id": "l2sspyautotest", "minimum_alive_secs": 300}' | base64)
+
+          aws lambda invoke \
+            --function-name ops-launchpad_token_dispenser \
+            --payload "$PAYLOAD" \
+            $OUTPUT_FILE > /dev/null 2>&1
+
+          if jq -e 'has("errorMessage")' "$OUTPUT_FILE" > /dev/null; then
+            echo "Error detected in Lambda response:"
+            cat "$OUTPUT_FILE"
+            exit 1
+          fi
+
+          RESULT=$(jq -r '.sm_token' < "$OUTPUT_FILE")
+          echo "::add-mask::$RESULT"
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials for UAT
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_CUMULUS_UAT }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_CUMULUS_UAT }}
+          aws-region: us-west-2
+
+      - name: Get Lauchpad Token UAT
+        id: launchpad_token_generator_uat
+        run: |
+          OUTPUT_FILE=result.json
+
+          PAYLOAD=$(echo '{"client_id": "l2sspyautotest", "minimum_alive_secs": 300}' | base64)
+
+          aws lambda invoke \
+            --function-name uat-launchpad_token_dispenser \
+            --payload "$PAYLOAD" \
+            $OUTPUT_FILE > /dev/null 2>&1
+
+          if jq -e 'has("errorMessage")' "$OUTPUT_FILE" > /dev/null; then
+            echo "Error detected in Lambda response:"
+            cat "$OUTPUT_FILE"
+            exit 1
+          fi
+
+          RESULT=$(jq -r '.sm_token' < "$OUTPUT_FILE")
+          echo "::add-mask::$RESULT"
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
       - name: Run diff
         id: diff
         env:
-          UAT_TOKEN_TEMP: ${{ secrets.LAUNCHPAD_TOKEN_UAT }}
-          OPS_TOKEN_TEMP: ${{ secrets.LAUNCHPAD_TOKEN_OPS }}
+          UAT_TOKEN_TEMP: ${{ steps.launchpad_token_generator_uat.outputs.result }}
+          OPS_TOKEN_TEMP: ${{ steps.launchpad_token_generator_ops.outputs.result }}
         run: |
           poetry install
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/diff.yml` to dynamically retrieve Launchpad tokens for both OPS and UAT environments using AWS Lambda, instead of relying on static secrets. This improves security and automation in the CI/CD process.

Key workflow automation and security improvements:

* Added steps to configure AWS credentials for both OPS and UAT environments using the `aws-actions/configure-aws-credentials@v3` action.
* Introduced steps to invoke AWS Lambda functions (`ops-launchpad_token_dispenser` and `uat-launchpad_token_dispenser`) to generate Launchpad tokens at runtime for OPS and UAT, respectively, masking the tokens in logs and exposing them as outputs.
* Updated the environment variables for the `Run diff` step to use the dynamically generated Launchpad tokens from the previous steps, replacing the use of static secrets.