### PR TITLE
fix token issue for tests

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,16 +36,44 @@ jobs:
         with:
           poetry-version: 2.3.2
 
-      - name: Get Environment and Concept ID
-        id: get-env-ccid
-        run: |
-          echo "test_env=$(python -c "print('${{ github.head_ref }}'.split('/')[1])")" >> $GITHUB_OUTPUT
-          echo "concept_id=$(python -c "print('${{ github.head_ref }}'.split('/')[2])")" >> $GITHUB_OUTPUT
-
       - name: Install Dependencies
         id: install
         run: |
           poetry install
+
+      - name: Get Environment and Concept ID
+        id: get-env-ccid
+        run: |
+          # Uses bash string splitting instead of spinning up Python
+          IFS='/' read -r prefix test_env concept_id <<< "${{ github.head_ref }}"
+          
+          echo "test_env=${test_env:-unknown}" >> "$GITHUB_OUTPUT"
+          echo "concept_id=${concept_id:-unknown}" >> "$GITHUB_OUTPUT"
+
+      - name: Set CMR bearer token dynamically
+        id: set-cmr-token
+        env:
+          # Securely map secrets to environment variables to prevent shell injection
+          UAT_TOKEN: ${{ secrets.UAT_URS_TOKEN }}
+          OPS_TOKEN: ${{ secrets.OPS_URS_TOKEN }}
+          # Grab the output from the first step
+          TARGET_ENV: ${{ steps.get-env-ccid.outputs.test_env }}
+        run: |
+          # Convert to uppercase in case the branch uses lowercase (e.g., 'uat' becomes 'UAT')
+          TARGET_ENV_UPPER="${TARGET_ENV^^}"
+
+          case "$TARGET_ENV_UPPER" in
+            UAT)
+              echo "CMR_BEARER_TOKEN=$UAT_TOKEN" >> "$GITHUB_ENV"
+              ;;
+            OPS)
+              echo "CMR_BEARER_TOKEN=$OPS_TOKEN" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "❌ Unknown environment: $TARGET_ENV" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Execute Tests
         id: run-tests
@@ -56,7 +84,7 @@ jobs:
           CMR_USER: ${{ secrets.CMR_USER }}
           CMR_PASS: ${{ secrets.CMR_PASS }}
         run: |
-          poetry run pytest verify_collection.py --concept_id $CONCEPT_ID --env $TEST_ENV --token-provider lambda --junitxml=$GITHUB_WORKSPACE/test-results/test_report.xml --html=$GITHUB_WORKSPACE/test-results/test_report.html || true
+          poetry run pytest verify_collection.py --concept_id $CONCEPT_ID --env $TEST_ENV --junitxml=$GITHUB_WORKSPACE/test-results/test_report.xml --html=$GITHUB_WORKSPACE/test-results/test_report.html || true
 
       - name: Convert XML to JSON
         id: run-xml-to-json


### PR DESCRIPTION
This pull request updates the `.github/workflows/verify.yml` workflow to improve environment variable handling, security, and reliability. The main changes involve switching from Python to Bash for branch name parsing, securely mapping secrets to environment variables, and dynamically setting the CMR bearer token based on the environment. Additionally, token provider arguments were removed from the test execution step.

**Workflow improvements:**

* Switched from using Python to Bash string splitting for extracting `test_env` and `concept_id` from the branch name, reducing dependencies and improving efficiency.
* Added a dedicated step to dynamically set the `CMR_BEARER_TOKEN` environment variable based on the extracted environment (`UAT` or `OPS`), securely mapping the appropriate secret and failing clearly on unknown environments.

**Security and reliability enhancements:**

* Improved secret handling by explicitly mapping secrets to environment variables within the workflow, reducing the risk of shell injection.
* Provided default values (`unknown`) for `test_env` and `concept_id` if parsing fails, increasing robustness.

**Test execution changes:**

* Removed the `--token-provider lambda` argument from the `pytest` command, as token management is now handled by the workflow environment.