### PR TITLE
Feature/update issue on failed regression

### DIFF
--- a/.github/workflows/new_regression.yml
+++ b/.github/workflows/new_regression.yml
@@ -23,6 +23,7 @@ jobs:
       environment: ${{ steps.prepare.outputs.environment }}
       environment_upper: ${{ steps.prepare.outputs.environment_upper }}
       harmony_status: ${{ steps.check-harmony.outputs.harmony_status }}
+      edl_status: ${{ steps.record-edl-status.outputs.edl_status }}
       matrix_chunks: ${{ steps.prepare.outputs.matrix_chunks }}
     steps:
       - uses: actions/checkout@v4
@@ -81,10 +82,22 @@ jobs:
           esac
 
       - name: Validate EDL token
+        id: validate-edl-token
+        continue-on-error: true
         uses: ./.github/actions/check-edl-token
         with:
           environment: ${{ steps.prepare.outputs.environment }}
           edl-token: ${{ steps.set-edl-token.outputs.edl_token }}
+
+      - name: Record EDL validation status
+        id: record-edl-status
+        if: always()
+        run: |
+          if [ "${{ steps.validate-edl-token.outcome }}" = "success" ]; then
+            echo "edl_status=up" >> "$GITHUB_OUTPUT"
+          else
+            echo "edl_status=down" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Generate Chunks
         if: ${{ steps.check-harmony.outputs.harmony_status == 'up' }}
@@ -134,7 +147,7 @@ jobs:
   process-chunks:
     needs: setup-and-chunk
     # Only run if there are actual chunks to process
-    if: ${{ needs.setup-and-chunk.outputs.harmony_status == 'up' && needs.setup-and-chunk.outputs.matrix_chunks != '[]' && needs.setup-and-chunk.outputs.matrix_chunks != '' }}
+    if: ${{ needs.setup-and-chunk.outputs.harmony_status == 'up' && needs.setup-and-chunk.outputs.edl_status == 'up' && needs.setup-and-chunk.outputs.matrix_chunks != '[]' && needs.setup-and-chunk.outputs.matrix_chunks != '' }}
     name: process-chunk-${{ matrix.chunk.id }}
     strategy:
       fail-fast: false
@@ -153,7 +166,7 @@ jobs:
   aggregate-failures:
     needs: [setup-and-chunk, process-chunks]
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.setup-and-chunk.outputs.harmony_status == 'up' && needs.setup-and-chunk.outputs.matrix_chunks != '[]' && needs.setup-and-chunk.outputs.matrix_chunks != '' }}
+    if: ${{ always() && needs.setup-and-chunk.outputs.harmony_status == 'up' && needs.setup-and-chunk.outputs.edl_status == 'up' && needs.setup-and-chunk.outputs.matrix_chunks != '[]' && needs.setup-and-chunk.outputs.matrix_chunks != '' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -210,3 +223,41 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           poetry run python tests/aggregate_results.py
+
+  update-alert-issue:
+    needs: setup-and-chunk
+    runs-on: ubuntu-latest
+    if: ${{ always() && (needs.setup-and-chunk.outputs.harmony_status != 'up' || needs.setup-and-chunk.outputs.edl_status != 'up') }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: 2.3.2
+
+      - name: Poetry Install
+        run: poetry install
+
+      - name: Update alert issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          args=(--env "${{ needs.setup-and-chunk.outputs.environment }}")
+
+          if [ "${{ needs.setup-and-chunk.outputs.harmony_status }}" != "up" ]; then
+            args+=(--alert "Harmony was unavailable, so regression aggregation was skipped for this run.")
+          fi
+
+          if [ "${{ needs.setup-and-chunk.outputs.edl_status }}" != "up" ]; then
+            args+=(--alert "EDL token validation failed, so regression jobs could not use Earthdata access.")
+          fi
+
+          poetry run python scripts/update_issue_alert.py "${args[@]}"

--- a/scripts/update_issue_alert.py
+++ b/scripts/update_issue_alert.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Prepend a runtime alert to the fixed regression issue for an environment."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+from typing import Iterable
+
+import requests
+
+
+ISSUE_NUMBERS = {
+    "UAT": 3919,
+    "OPS": 3973,
+}
+
+ALERT_BLOCK_RE = re.compile(
+    r"<!-- regression-alert:start -->.*?<!-- regression-alert:end -->\n*",
+    re.DOTALL,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prepend an alert message to the fixed regression issue body for "
+            "the selected environment."
+        )
+    )
+    parser.add_argument(
+        "--env",
+        required=True,
+        help="Target environment: uat or ops.",
+    )
+    parser.add_argument(
+        "--alert",
+        action="append",
+        dest="alerts",
+        default=[],
+        help="Alert text to prepend. Pass multiple times to include more than one line.",
+    )
+    return parser.parse_args()
+
+
+def get_issue_number(env: str) -> int:
+    env_key = env.upper()
+    if env_key not in ISSUE_NUMBERS:
+        raise ValueError(f"Unsupported environment: {env}")
+    return ISSUE_NUMBERS[env_key]
+
+
+def build_alert_block(alerts: Iterable[str]) -> str:
+    pacific = ZoneInfo("America/Los_Angeles")
+    timestamp = datetime.now(timezone.utc).astimezone(pacific).strftime("%Y-%m-%d %H:%M:%S %Z")
+    lines = [
+        "<!-- regression-alert:start -->",
+        f"**Alert** - {timestamp}",
+    ]
+    for alert in alerts:
+        lines.append(f"- {alert}")
+    lines.append("<!-- regression-alert:end -->")
+    return "\n".join(lines)
+
+
+def strip_existing_alert(body: str) -> str:
+    return ALERT_BLOCK_RE.sub("", body or "")
+
+
+def fetch_issue(repo: str, token: str, issue_number: int) -> dict:
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    response = requests.get(url, headers=headers, timeout=20)
+    response.raise_for_status()
+    return response.json()
+
+
+def update_issue(repo: str, token: str, issue_number: int, body: str) -> None:
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    response = requests.patch(url, headers=headers, json={"body": body}, timeout=20)
+    response.raise_for_status()
+
+
+def main() -> int:
+    args = parse_args()
+
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    token = os.environ.get("GITHUB_TOKEN")
+    if not repo or not token:
+        print("GITHUB_REPOSITORY and GITHUB_TOKEN are required.", file=sys.stderr)
+        return 1
+
+    if not args.alerts:
+        print("At least one --alert message is required.", file=sys.stderr)
+        return 1
+
+    try:
+        issue_number = get_issue_number(args.env)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    issue = fetch_issue(repo, token, issue_number)
+    existing_body = strip_existing_alert(issue.get("body", ""))
+    existing_body = existing_body.lstrip("\n")
+
+    alert_block = build_alert_block(args.alerts)
+    if existing_body:
+        new_body = f"{alert_block}\n\n{existing_body}"
+    else:
+        new_body = alert_block
+
+    update_issue(repo, token, issue_number, new_body)
+    print(f"Updated issue #{issue_number} with alert for {args.env.upper()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request enhances the regression workflow to improve handling and visibility of failures related to EDL token validation and Harmony service status. The main changes include tracking EDL validation status throughout the workflow, conditionally running regression jobs only when both Harmony and EDL are available, and introducing automated alerts to a fixed GitHub issue when either service is down.

**Workflow enhancements for EDL and Harmony status:**

* Added steps to validate the EDL token, record its status, and propagate this status through workflow outputs in `.github/workflows/new_regression.yml`. [[1]](diffhunk://#diff-b75274e7999dd3a2f63e14a512febbc7ab14e464badc02491492da42a84ea10dR85-R101) [[2]](diffhunk://#diff-b75274e7999dd3a2f63e14a512febbc7ab14e464badc02491492da42a84ea10dR26)
* Updated conditional logic for the `process-chunks` and `aggregate-failures` jobs to require both Harmony and EDL to be up before proceeding. [[1]](diffhunk://#diff-b75274e7999dd3a2f63e14a512febbc7ab14e464badc02491492da42a84ea10dL137-R150) [[2]](diffhunk://#diff-b75274e7999dd3a2f63e14a512febbc7ab14e464badc02491492da42a84ea10dL156-R169)

**Automated alerting for service failures:**

* Added a new `update-alert-issue` job that runs when either Harmony or EDL is down, which posts a timestamped alert to a fixed issue in the repository using a new script.
* Introduced the `scripts/update_issue_alert.py` script, which prepends alert messages to the appropriate issue for the affected environment, ensuring visibility of workflow failures.