### PR TITLE
Fix automation issues

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -121,9 +121,9 @@ jobs:
       - name: Enable Pull Request Automerge
         if: steps.existing_pr.outputs.exists != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.podaac-cicd.outputs.token }}
         run: gh pr merge --merge --auto ${{ steps.cpr.outputs.pull-request-number }}
-  
+
 
   open_pr_ops:
     needs: find_new
@@ -179,6 +179,5 @@ jobs:
       - name: Enable Pull Request Automerge
         if: steps.existing_pr.outputs.exists != 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.podaac-cicd.outputs.token }}
         run: gh pr merge --merge --auto ${{ steps.cpr.outputs.pull-request-number }}
-  

--- a/tests/remove_prs.py
+++ b/tests/remove_prs.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 
     # Print each open pull request title and URL
     for pull in open_pulls:
-        if pull.title not in new_collection_titles:
+        if pull.title not in new_collection_titles and any(label.name == 'autotest' for label in pull.labels):
             # Close the pull request
             pull.edit(state='closed')
             print(f"Pull Request #{pull.number}: {pull.title} have been closed")


### PR DESCRIPTION
This PR fixes:
- PR merged or closed did not have their PODAAC project status automatically updated to "closed". This was because of a protection of github action which prevent multiple call of a github action when the default github.token is used.
- manually created PR were automatically closed: afiner test in the remove_prs.py should prevent this issue. 

The fixes were written by AI and they make sense to me, I did not test them as it is tricky to do from a branch of the repository. But I believe the worst which can happen if we merge is that none of the expected fixes work.